### PR TITLE
Fix for the issue where Asset Bundles were not loading when a slide is re-opened

### DIFF
--- a/Assets/AN-PrezSDK/Runtime/Scripts/PrezSDKManager.cs
+++ b/Assets/AN-PrezSDK/Runtime/Scripts/PrezSDKManager.cs
@@ -263,6 +263,9 @@ class PrezSDKManager : MonoBehaviour
         //Terminate the asset loading process
         AssetLoader.StopLoadingAssets();
 
+        //Cleanup assetbundles
+        AssetBundleManager.Cleanup();
+
         //Destroy the already loaded assets
         previousSlide.DestroyLoadedObjects();
 


### PR DESCRIPTION
While changing/re-opening slides, all the previously loaded assets should get destroyed. Assetbundles are also getting destroyed but not unloaded in a proper way. That has been fixed by calling **CleanUp** method of **AssetBundleManager** class.