### PR TITLE
Removing the 'PresentationManager' component from PresentationAnchorOverride on Quit

### DIFF
--- a/Assets/AN-PrezSDK/Runtime/Scripts/PrezSDKManager.cs
+++ b/Assets/AN-PrezSDK/Runtime/Scripts/PrezSDKManager.cs
@@ -176,6 +176,9 @@ class PrezSDKManager : MonoBehaviour
 
         prezAssets.Clear();
         _manager._location = null;
+
+        //Remove PresentationManager from the presentationAnchorOverride
+        Destroy(presentationAnchorOverride.GetComponent<PresentationManager>());
     }
 
 


### PR DESCRIPTION
When a user quits a presentation, the 'PresentationManager.cs' component attached to the PresentationAnchor was not removed. Due to this when the user loads a new or same presentation, a 'PresentationManager.cs' component will be added again. This doesn't cause any functional issues but it's not efficient.