### PR TITLE
Fixed the issue regarding asset OnCommand transition issue

### DIFF
--- a/Assets/AN-PrezSDK/Runtime/Scripts/PrezSDKManager.cs
+++ b/Assets/AN-PrezSDK/Runtime/Scripts/PrezSDKManager.cs
@@ -239,7 +239,7 @@ class PrezSDKManager : MonoBehaviour
     {
         if (isPlaying)
         {
-            if (!animationTimeline.FirstElementAutomatic && LastPlayedPoint == -1)
+            if (!animationTimeline.FirstElementAutomatic)
             {
                 SlidePoint = 0;
                 LastPlayedPoint = animationTimeline.Play(SlidePoint);


### PR DESCRIPTION
Sometimes for assets that has OnCommand as transition it takes two clicks on "Next Step" button to load the asset